### PR TITLE
Eliminate roll-ups (no longer required) from both raw and name-value processing; Upgrade Jackson release

### DIFF
--- a/nester/pom.xml
+++ b/nester/pom.xml
@@ -21,7 +21,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
-		<jackson-2-version>2.7.3</jackson-2-version>
+		<jackson-2-version>2.8.5</jackson-2-version>
 	</properties>
 
 	<dependencies>

--- a/nester/src/main/java/com/memoriesdreamsandreflections/nester/ContainerLevel.java
+++ b/nester/src/main/java/com/memoriesdreamsandreflections/nester/ContainerLevel.java
@@ -17,15 +17,7 @@ package com.memoriesdreamsandreflections.nester;
 
 
 import java.lang.reflect.Field;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
 import java.util.Objects;
-import java.util.TreeMap;
-import java.util.stream.Collectors;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Simple greeter class.
@@ -34,13 +26,13 @@ import org.slf4j.LoggerFactory;
  */
 @SuppressWarnings( { "rawtypes" } )
 
-public abstract class ContainerLevel<T>
+public abstract class ContainerLevel<T, C>
 {
 	CategoryDescriptor<T> descriptor;
 	Object lastValue;
-	List container;
+	C container;
 	boolean valueBreak;
-	boolean reset;
+	boolean reset = true;
 
 	public ContainerLevel( CategoryDescriptor<T> descriptor ) throws NoSuchFieldException, SecurityException
 	{
@@ -67,17 +59,12 @@ public abstract class ContainerLevel<T>
 		return valueBreak;
 	}
 
-	public void setValueBreak( boolean valueBreak )
-	{
-		this.valueBreak = valueBreak;
-	}
-
-	public List getContainer()
+	public C getContainer()
 	{
 		return container;
 	}
 
-	public void setContainer( List container )
+	public void setContainer( C container )
 	{
 		this.container = container;
 	}
@@ -114,10 +101,7 @@ public abstract class ContainerLevel<T>
 		reset = false;
 	}
 
-	public List newContainer()
-	{
-		return (container = new ArrayList(2));
-	}
+	public abstract C newContainer();
 
 	public void reset()
 	{


### PR DESCRIPTION
Eliminate roll-ups from raw and name/value processing; Upgrade Jackson version